### PR TITLE
v0.1_template

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ def run_parse(session):
     
 @nox.session
 def run_generate(session):
-    session.install('pyyaml')
+    session.install('pyyaml', 'jinja2')
     session.cd('src/Build/parse')
     session.run('python', 'generate.py')
     session.cd('../../..')

--- a/src/Build/parse/template.j2
+++ b/src/Build/parse/template.j2
@@ -1,0 +1,44 @@
+import gradio
+import skimage
+import scipy
+import numpy
+import os
+import sys
+
+# # Add this directory to the Python path
+# sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Import the function from the script
+from {{ exec_function.script }} import {{ exec_function.name }}
+
+# Inputs to be shown in the GUI
+inputs = [
+    {% for input in inputs %}
+    {% if input.type == 'Files' %}
+    gradio.Files(file_count='{{ input.file_count }}', label='{{ input.label }}'),
+    {% elif input.type == 'Radio' %}
+    gradio.Radio({{ input.options | tojson }}, type='value', value='{{input.options[0].value}}', label='{{ input.label }}'),
+    {% elif input.type == 'Number' %}
+    gradio.Number(value={{ input.value }}, interactive={{ input.interactive }}, label='{{ input.label }}'),
+    {% endif %}
+    {% endfor %}
+]
+
+# Outputs to be shown in the GUI
+output = [
+    {% for output in outputs %}
+    {% if output.type == 'Files' %}
+    gradio.File(label='{{ output.label }}'),
+    {% endif %}
+    {% endfor %}
+]
+
+demo = gradio.Interface(
+    fn={{ exec_function.name }},
+    inputs=inputs,
+    outputs=output,
+    title="Simple ID objects"
+)
+
+if __name__ == "__main__":
+    demo.launch(server_name="0.0.0.0", server_port=8000)


### PR DESCRIPTION
Resolves #17, #8, #11, #13, #16

1. Here, We need a modification for the code https://github.com/bilayer-containers/bilayers/blob/152bc1a9913c4841fb3a4e28d2177952ecdd1214/src/Build/parse/template.j2#L20

I want it to display like just `Otsu` and `Li` as a Radio button option instead of 

<img width="472" alt="Screenshot 2024-06-24 at 4 05 28 PM" src="https://github.com/bilayer-containers/bilayers/assets/122663941/a0cc6734-2043-4e21-b938-22cb42badbe7">



2. Secondly, if we can directly `parse` the `config-file` instead of pre-parsing this - basically checking if we have those input types, it would be good
https://github.com/bilayer-containers/bilayers/blob/152bc1a9913c4841fb3a4e28d2177952ecdd1214/src/Build/parse/generate.py#L6