### PR TITLE
V0.1 enhance cellpose

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,11 @@ def build_algorithm(session):
             name = config.get('docker-image', {}).get('name')
             tag = config.get('docker-image', {}).get('tag')
             docker_image_name = f'{org}/{name}:{tag}' if org and name and tag else None
-            
+
+            # Save the Docker image name in a file
+            with open('/tmp/docker_image_name.txt', 'w') as file:
+                file.write(docker_image_name)
+                
             if docker_image_name:
                 print(f'Found Docker image name in config: {docker_image_name}')
                 # Pull the Docker image from DockerHub
@@ -76,10 +80,11 @@ def build_interface(session):
     dockerfile_path = f'src/Build/Dockerfiles/Dockerfile'
     print("Dockerfile Path: ", dockerfile_path)
 
-    # Take the input from build_docker.sh file pass it whilst building the image
-    algorithm_name = session.posargs[1] 
+    # Read the Docker image name from the file
+    with open('/tmp/docker_image_name.txt', 'r') as file:
+        base_image = file.read().strip()
 
-    session.run('docker', 'build', '--build-arg',  f'ALGORITHM_NAME={algorithm_name}', '-t', image_name, '-f', dockerfile_path, 'src/Build')
+    session.run('docker', 'build', '--build-arg',  f'BASE_IMAGE={base_image}', '-t', image_name, '-f', dockerfile_path, 'src/Build')
 
 @nox.session
 def install_gradio(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,27 +17,6 @@ def run_generate(session):
     session.run('python', 'generate.py')
     session.cd('../../..')
 
-# Prevoiusly, we had more basic nox-session for building the Algorithm docker image
-# @nox.session
-# def build_algorithm(session):
-#     """Build the Algorithm docker Image"""
-#     if len(session.posargs) > 0:
-#         algorithm = session.posargs[0] 
-#     else:
-#         algorithm = 'threshold'
-#     print("Building Algorithm Nox-File: ", algorithm)
-#     image_name = f'{algorithm}-image'
-#     print("Image Name: ", image_name)
-#     dockerfile_path = f'src/Algorithms/{algorithm}/Dockerfile'
-#     print("Dockerfile Path: ", dockerfile_path)
-
-#     # If Dockerfile doesn't exist for the specified algorithm
-#     if not os.path.exists(dockerfile_path):
-#         print(f'Dockerfile for {algorithm} not found at {dockerfile_path}')
-#         session.error(f'Dockerfile for {algorithm} not found at {dockerfile_path}')
-#     session.run('docker', 'build', '-t', image_name, '-f', dockerfile_path, f'src/Algorithms/{algorithm}')
-
-
 @nox.session
 def build_algorithm(session):
     """Build the Algorithm docker Image"""

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -25,7 +25,7 @@ for ALGORITHM_NAME in "${ALGORITHM_NAMES[@]}";
         nox -s build_algorithm -- $ALGORITHM_NAME
 
         # Building the Interface Docker image
-        nox -s build_interface -- $INTERFACE_NAME $ALGORITHM_NAME
+        nox -s build_interface -- $INTERFACE_NAME
 
         # Installing the Graadio interface
         nox -s install_gradio

--- a/src/Algorithms/cellpose/config.yaml
+++ b/src/Algorithms/cellpose/config.yaml
@@ -21,10 +21,11 @@ inputs:
  
   # Input Image Arguments
   - name: dir
-    type: Textbox
+    type: Files
     label: "Input Image Directory"
     description: "Path to the directory of input images"
-    value: ""
+    file_count: "directory"
+    default: "directory"
     cli_tag: "--dir"
     section_id: "input-args"
     mode: "beginner"
@@ -37,6 +38,15 @@ inputs:
     optional: True
     section_id: "input-args"
     mode: "advanced"
+  - name: image_filter
+    type: Textbox
+    label: "Image Filter"
+    description: "filter for image files"
+    default: ""
+    cli_tag: "--img_filter"
+    optional: True
+    section_id: "input-args"
+    mode: "advanced" 
   - name: channel_axis
     type: Radio
     label: "Channel Axis"
@@ -122,7 +132,15 @@ inputs:
     optional: False
     section_id: "model-args"
     mode: "beginner"
-    # Rest Arguments of Model are for Cellpose v3
+  - type: Files
+    label: "Add Model"
+    description: "add custom model to use"
+    file_count: "single"
+    default: "single"
+    cli_tag: "--add_model"
+    optional: True
+    section_id: "model-args"
+    mode: "advanced"
 
     # Algorithm Arguments
   - name: no_resample
@@ -253,7 +271,6 @@ inputs:
     optional: True
     section_id: "output-args"
     mode: "advanced"
-  # save_dir is a directory
   - name: dir_above
     type: Checkbox
     label: "Dir Above"
@@ -333,41 +350,12 @@ exec_function:
   script: "cellpose"
   module: "Algorithms.cellpose"
   cli_command: "python -m cellpose --verbose"
-  cli_args: 
-    - "--use_gpu" 
-    - "--gpu_device"
-    - "--dir"
-    - "--look_one_level_down"
-    - "--channel_axis"
-    - "--chan" 
-    - "--chan2" 
-    - "--invert" 
-    - "--all_channels" 
-    - "--pretrained_model" 
-    - "--no_resample" 
-    - "--no_interp" 
-    - "--no_norm" 
-    - "--do_3D" 
-    - "--diameter"
-    - "--stitch_threshold"
-    - "--min_size" 
-    - "--fast_mode" 
-    - "--flow_threshold" 
-    - "--cellprob_threshold"
-    - "--exclude_on_edges"
-    - "--save_png" 
-    - "--save_tif" 
-    - "--no_npy"
-    # - "--save_dir" : []
-    - "--dir_above" 
-    - "--in_folders" 
-    - "--save_flows" 
-    - "--save_outlines" 
-    - "--save_ncolor" 
-    - "--save_txt" 
+  hidden_args:
+    # dummy example
+    # - cli_tag: "--save_png"
+    #   value: True
 
 docker-image:
   org: cellprofiler
   name: runcellpose_no_pretrained
   tag: 0.1
-  # -> cellprofiler/runcellpose_no_pretrained:0.1

--- a/src/Algorithms/cellpose/config.yaml
+++ b/src/Algorithms/cellpose/config.yaml
@@ -61,6 +61,15 @@ inputs:
     optional: True
     section_id: "input-args"
     mode: "advanced"
+  - name: z_axis
+    type: Number
+    label: "Z Axis"
+    description: "axis of image which corresponds to z dimension"
+    default: None
+    cli_tag: "--z_axis"
+    optional: True
+    section_id: "input-args"
+    mode: "advanced"
   - name: chan
     type: Radio
     label: "Chan To Segment"
@@ -233,6 +242,15 @@ inputs:
     optional: True
     section_id: "algorithm-args"
     mode: "advanced"
+  - name: anisotropy
+    type: Number
+    label: "Anisotropy"
+    description: "anisotropy of image"
+    default: 1.0
+    cli_tag: "--anisotropy"
+    optional: True
+    section_id: "algorithm-args"
+    mode: "advanced"
   - name: exclude_on_edges
     type: Checkbox
     label: "Exclude On Edges"
@@ -357,5 +375,5 @@ exec_function:
 
 docker-image:
   org: cellprofiler
-  name: runcellpose_no_pretrained
+  name: runcellpose_with_pretrained
   tag: 0.1

--- a/src/Build/Dockerfiles/Dockerfile
+++ b/src/Build/Dockerfiles/Dockerfile
@@ -1,5 +1,8 @@
+# Argument that takes Algorithm-Image-Name as input
+ARG BASE_IMAGE
+
 # From algorithm image
-FROM cellprofiler/runcellpose_no_pretrained:0.1
+FROM $BASE_IMAGE
 
 # Set the working directory within the container
 WORKDIR /bilayers

--- a/src/Build/parse/template.j2
+++ b/src/Build/parse/template.j2
@@ -1,26 +1,11 @@
 import os
 import gradio as gr
 import subprocess
+import tempfile
+import shutil
 
-def generate_cli_command(**kwargs):
+def generate_cli_command(cli_tags, **kwargs):
     cli_command = ["{{ exec_function.cli_command }}"]
-    
-    #Mapping CLI tags to arguments
-    cli_args = {
-    {% for arg in exec_function.cli_args %}
-        "{{ arg }}": None{% if not loop.last %}, {% endif %}
-    {% endfor %}
-    }
-
-    # User inputs with their CLI tags and default values
-    cli_tags = {
-    {% for input_conf in inputs %}
-        "{{ input_conf.label | lower | replace(' ', '_') }}": {
-            "cli_tag": "{{ input_conf.cli_tag }}",
-            "default": "{{ input_conf.default }}"
-        }{% if not loop.last %}, {% endif %}
-    {% endfor %}
-    }
 
     # Radio options mapping
     radio_options = {
@@ -33,32 +18,49 @@ def generate_cli_command(**kwargs):
     {% endfor %}
     }
 
+    temp_dir = None
+
     # Update cli_args with user inputs or defaults
     for key, value in kwargs.items():
         if key in cli_tags:
+            cli_tag = cli_tags[key]["cli_tag"]
+            default = cli_tags[key].get("default", None)
+
             if isinstance(value, bool):
                 if value:  # Only include the flag if it is True
-                    cli_args[cli_tags[key]["cli_tag"]] = ""
+                    cli_command.append(cli_tag)
             else:
                 # Handle Radio type mappings dynamically
                 if key in radio_options and value in radio_options[key]:
                     value = radio_options[key][value]
-                cli_args[cli_tags[key]["cli_tag"]] = value
+                # If the input is a list (mainly for input files), convert it to a string
+                elif isinstance(value, list):
+                    if default == "directory":
+                        # Create a temporary directory and move all the input files there
+                        temp_dir = tempfile.mkdtemp()
+                        for file_path in value:
+                            shutil.copy(file_path, temp_dir)
+                        value = temp_dir
+                    else:
+                        value = value[0]
+                # If the value of textbox is empty string, set it to None
+                if value == "":
+                    value = None
+                # If the value is None, append it
+                if value is not None:
+                    cli_command.append(f"{cli_tag} {value}")
 
-    # Construct the CLI command
-    for tag, value in cli_args.items():
-        if value is not None:
-            if value == "":
-                cli_command.append(f"{tag}")
-            else:
-                cli_command.append(f"{tag} {value}")
-        else:
-            # Add default value if not provided by user
-            for key, val in cli_tags.items():
-                if val["cli_tag"] == tag and val["default"]:
-                    cli_command.append(f"{tag} {val['default']}")
-
-    return " ".join(cli_command)
+   # Add hidden arguments to the command
+    {% if exec_function.hidden_args %}
+    {% for arg in exec_function.hidden_args %}
+    if {{ arg.value }} == True:
+        cli_command.append("{{ arg.cli_tag }}")
+    else:
+        cli_command.append("{{ arg.cli_tag }} {{ arg.value }}")
+    {% endfor %}
+    {% endif %}
+    
+    return " ".join(cli_command), temp_dir
 
 # Dynamically define on_submit with the exact input arguments
 def on_submit({% for input_conf in inputs %}{{ input_conf.label | lower | replace(' ', '_') }}{% if not loop.last %}, {% endif %}{% endfor %}):
@@ -67,19 +69,37 @@ def on_submit({% for input_conf in inputs %}{{ input_conf.label | lower | replac
         "{{ input_conf.label | lower | replace(' ', '_') }}": {{ input_conf.label | lower | replace(' ', '_') }}{% if not loop.last %}, {% endif %}
     {% endfor %}
     }
+
+    cli_tags = {
+    {% for input_conf in inputs %}
+        "{{ input_conf.label | lower | replace(' ', '_') }}": {
+            "cli_tag": "{{ input_conf.cli_tag }}",
+            "default": "{{ input_conf.default }}"
+        }{% if not loop.last %}, {% endif %}
+    {% endfor %}
+    }
+
     print("Received inputs:", kwargs)
 
-    cli_command = generate_cli_command(**kwargs)
+    # Generate the CLI command
+    cli_command, temp_dir = generate_cli_command(cli_tags, **kwargs)
     print("Generated CLI command:", cli_command)
 
     # Execute the CLI command
     try:
         result = subprocess.run(cli_command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print("Command output:", result.stdout.decode())
+
+        # Display Output files
+        output_files = []
+        if temp_dir:
+            output_files.extend([os.path.join(temp_dir, f) for f in os.listdir(temp_dir) if os.path.isfile(os.path.join(temp_dir, f))])
+
+        return output_files
+
     except subprocess.CalledProcessError as e:
         print("Command failed with error:", e.stderr.decode())
-
-
+        return []
 
 
 {% for input_conf in inputs %}
@@ -91,6 +111,13 @@ def on_submit({% for input_conf in inputs %}{{ input_conf.label | lower | replac
 {{ input_conf.label | lower | replace(" ", "_") }} = gr.Textbox(label="{{ input_conf.label }}", value="{{ input_conf.default }}")
 {% elif input_conf.type == 'Checkbox' %}
 {{ input_conf.label | lower | replace(" ", "_") }} = gr.Checkbox(label="{{ input_conf.label }}", value={{ input_conf.value }})
+{% elif input_conf.type == 'Files' %}
+{{ input_conf.label | lower | replace(" ", "_") }} = gr.File(label="{{ input_conf.label }}", file_count="{{ input_conf.file_count }}")
+{% endif %}
+{% endfor %}
+
+{% for output_conf in outputs %}
+{% if output_conf.type == 'Files' %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
### This PR helps us to run all the parameters for cellpose(v2) 2D in docker and locally too:
Steps to run:-
- `chmod +x build_docker.sh`
- `sh build_docker.sh`
- `docker run -d -p 8000:8000 --name gradio-container gradio-image`
- And play around within docker

### The changes done from last PR(https://github.com/bilayer-containers/bilayers/pull/18):
1. We have now moved logic from dealing with `cli_tags` in `inputs` and `cli_args` in `exec_function` to only mentioning `cli_tags` in `config.yaml` file. To deal with the arguments which by default we want to pass and not expose that to user at `Gradio Interface` level, we can now put those in exec_function.hidden_args`. 
2. Instead of volume mount, the file now will take `Files` as inputs via `gradio.Files` and putting `file_count` as `directory`. 
3. Output display thing is resolved.


### I feel, the following aspects require refactoring or improved edge case handling:
1. @gnodar01 As of now, I am taking all the input images and making a temporary directory, storing all the files in it and then passing the name of it to `--dir` argument. I tried using `os.pathname.dirname(value[0])` but it was weirdly taking the first file instead of taking all the files. Is there a better way to do it? [Current Logic link here](https://github.com/bilayer-containers/bilayers/blob/v0.1_enhance_cellpose/src/Build/parse/template.j2#L37)
2. I feel if the user chooses pre-trained-model then he shouldn't be able to upload `--add_model`, right?
3.  Still, this is hardcoded `FROM cellprofiler/runcellpose_no_pretrained:0.1` in dockerfile. I was wondering, how should I make it pass from CI/CD. My first instinct goes for using environment variables and storing the name of pulled docker and passing it.
4. A rigorous testing!

### The problem:
1. `--savedir` : If user passes the directory folder, which would be his local path, how the docker would identify the path and help save the output to that path?
2. `--z_axis` : I wasn't sure about the input type and after pushing the code got some links from Shata, to check-out.
