### PR TITLE
JupyterNB Error directly reports to bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -29,7 +29,7 @@ body:
       placeholder: Steps to reproduce the bug
       value: |
         ```
-        Your config.yaml content here : For custom algorithm
+          # Your config.yaml content here : For custom algorithm
         ```
     validations:
       required: true
@@ -57,8 +57,8 @@ body:
     attributes: 
         label: System Info
         description: Fill out the system's specification
-        placeholder: OS version 
+        placeholder: OS version = MacOS Sonoma 14.1 
         value: |
-            OS version: MacOS Sonoma 14.1
+            OS version: 
     validations: 
         required: true

--- a/src/Build/parse/jupyter_shell_command_template.py.j2
+++ b/src/Build/parse/jupyter_shell_command_template.py.j2
@@ -1,9 +1,9 @@
 import subprocess
 import nbformat as nbf
 from IPython.core.getipython import get_ipython
-from IPython.display import display, FileLink
-from zipfile import ZipFile, ZIP_DEFLATED
-from pathlib import Path
+from IPython.display import display, FileLink, HTML
+import traceback
+import urllib.parse
 
 try:
     res = subprocess.run(cli_command.value, shell=True, check=True, stdout=None, stderr=subprocess.PIPE)
@@ -13,14 +13,35 @@ try:
      
 
 except Exception as e:
-    error_message = str(e)
-    # print(f"Error occurred: {{error_message}}")
-    error_cell = nbf.v4.new_code_cell(f"# Error Details: {{error_message}}")
+    # Capture the full stack trace
+    error_message = traceback.format_exc()
 
-    ####################
-    # Display the error cell
-    shell = get_ipython()
-    shell.payload_manager.write_payload(dict(
-    source='set_next_input',
-    text=error_cell['source'],
-    replace=False), single=False)
+    # Helps turning the error message into a URL-friendly format
+    encoded_error_message = urllib.parse.quote_plus(f"## Logs\n```\n{error_message}\n```")
+
+    # Construct the GitHub issue URL, pre-filling the "logs" section with the stack trace
+    issue_url = f"https://github.com/bilayer-containers/bilayers/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml&logs={encoded_error_message}"
+
+    # Display the link as a styled button, centered
+    button_html = f'''
+        <div style="text-align: center; margin-top: 20px;">
+            <a href="{issue_url}" target="_blank" style="
+                display: inline-block;
+                padding: 10px 20px;
+                font-size: 16px;
+                color: white;
+                background-color: #ff0000;
+                border-radius: 5px;
+                text-align: center;
+                text-decoration: none;
+                font-family: Arial, sans-serif;
+            ">
+                Report Issue
+            </a>
+        </div>
+    '''
+
+    display(HTML(button_html))
+
+    # Also, print the error message 
+    print(f"Full Stack Trace:\n{error_message}")


### PR DESCRIPTION
Closes #33 

Error raised in JupyterNB could be directly reported to bug_report template with pre-filled Traceback information

<img width="1348" alt="Screenshot 2024-09-27 at 10 46 43 AM" src="https://github.com/user-attachments/assets/47398bf1-547d-4eea-8420-d8b2a336997f">
<img width="1142" alt="Screenshot 2024-09-27 at 10 47 18 AM" src="https://github.com/user-attachments/assets/62263798-0485-4994-ab51-28b1311fa76d">


I wanted to discuss a better way to pass log information. Currently, the log details are being passed through the URL to the template. However, if the URL reaches its maximum length capacity, the entire error message may not be passed to the template

@gnodar01 feel free to review this at your convenience