### PR TITLE
Fixing some recently noticed problems

### DIFF
--- a/src/Build/Dockerfiles/Gradio.Dockerfile
+++ b/src/Build/Dockerfiles/Gradio.Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /bilayers
 RUN python -m pip install pyyaml gradio==4.36.1 gradio_client==1.0.1 huggingface-hub==0.23.4 pydantic==2.7.4
 
 # Install numpy and opencv-python
-RUN python -m pip install numpy==1.23.0 opencv-python-headless==4.5.3.56 matplotlib==3.5.1
+RUN python -m pip install numpy==1.23.0 opencv-python-headless==4.5.3.56 matplotlib==3.5.1 fastapi==0.112.0
 
 # Add app.py file to the container
 ADD parse/generated_folders/$FOLDER_NAME/app.py /bilayers/

--- a/src/Build/Dockerfiles/Gradio.Dockerfile
+++ b/src/Build/Dockerfiles/Gradio.Dockerfile
@@ -10,10 +10,10 @@ ARG FOLDER_NAME
 WORKDIR /bilayers
 
 # Install the dependencies for the gradio app
-RUN python -m pip install pyyaml gradio==4.36.1 gradio_client==1.0.1 huggingface-hub==0.23.4 pydantic==2.7.4
+RUN python -m pip install pyyaml gradio==4.43.0 gradio_client==1.3.0 huggingface-hub==0.23.4 pydantic==2.7.4
 
 # Install numpy and opencv-python
-RUN python -m pip install numpy==1.23.0 opencv-python-headless==4.5.3.56 matplotlib==3.5.1 fastapi==0.112.0
+RUN python -m pip install numpy==1.23.0 opencv-python-headless==4.5.3.56 matplotlib==3.5.1
 
 # Add app.py file to the container
 ADD parse/generated_folders/$FOLDER_NAME/app.py /bilayers/

--- a/src/Build/parse/gradio_template.py.j2
+++ b/src/Build/parse/gradio_template.py.j2
@@ -284,7 +284,7 @@ def on_submit(
 
     # Execute the CLI command
     try:
-        result = subprocess.run(cli_command, shell=True, check=True, stdout=None, stderr=subprocess.PIPE)
+        result = subprocess.run(cli_command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print("Command executed successfully")
         
         # Check if output_folder_name is not None and is a directory


### PR DESCRIPTION
There were no open issues about the current changes made, it's just a recent encounter of a couple of errors 

Recently, I encountered some issues - 

1. When running the `cli_command` on clicking `on_submit()`, I attached screenshot error. It was resolved by installing FastAPI to Gradio.Dockerfile, although I'm not sure why `Pydantic` would need `FastAPI`. The issue seems to be resolved, but I don't have a clear understanding of why this works. Do you have any alternative solutions, @gnodar01?
<img width="833" alt="img-err" src="https://github.com/user-attachments/assets/5d17069f-bb55-4352-b0e5-6d239d3f0ae1">


2. And since our function [here](https://github.com/bilayer-containers/bilayers/blob/main/src/Build/parse/gradio_template.py.j2#L290-L300) requires the output of the subprocess, we need to capture it by changing stdout=subprocess.None to stdout=subprocess.PIPE. Without this change, when a custom folder_name is provided for saving the output, Nothing is displayed (no files are returned) in the Gradio interface
3. @gnodar01 Have you mapped to a port other than `-p 8000:7878` while running the Docker image, and if so, is Gradio still able to run and produce the correct output? For me it's not
<img width="1630" alt="Screenshot 2024-10-04 at 3 30 25 PM" src="https://github.com/user-attachments/assets/68b1e002-302d-4f9f-ac77-bb9faa6f108c">
<img width="445" alt="Screenshot 2024-10-04 at 3 30 47 PM" src="https://github.com/user-attachments/assets/7b3dbe2c-cdf9-41d3-baa4-77e366611fe8">

Here, I was not able to get `--save_flows` and `--save_txt` 's outputs