### PR TITLE
Threshold works with cli_tags (custom threshold.py)

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -4,7 +4,7 @@
 set -e
 
 # List of algorithms and interfaces
-ALGORITHM_NAMES=("cellpose_inference") 
+ALGORITHM_NAMES=("threshold_inference" "cellpose_inference")
 INTERFACE_NAMES=("gradio" "jupyter") 
 
 # Build the Docker images for each algorithm and interface
@@ -26,7 +26,7 @@ for ALGORITHM_NAME in "${ALGORITHM_NAMES[@]}";
         nox -s build_algorithm -- $ALGORITHM_NAME
 
         # Building the Interface Docker image
-        nox -s build_interface -- $INTERFACE_NAME
+        nox -s build_interface -- $INTERFACE_NAME $ALGORITHM_NAME
 
         # Installing the Graadio interface
         nox -s install_gradio

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,67 +22,71 @@ def run_generate(session):
 def build_algorithm(session):
     """Build the Algorithm docker Image"""
     if len(session.posargs) > 0:
-        algorithm = session.posargs[0] 
+        algorithm = session.posargs[0]
         print("Algorithm Name in build_algorithm session: ", algorithm)
     else:
-        algorithm = 'threshold'
+        algorithm = 'threshold_inference'
     
     print("Building Algorithm Nox-File: ", algorithm)
     image_name = f'{algorithm}'
     print("Image Name: ", image_name)
-    dockerfile_path = f'src/Algorithms/{algorithm}/Dockerfile'
-    config_file_path = f'src/Algorithms/{algorithm}/config.yaml'
+    dockerfile_path = f'src/algorithms/{algorithm}/Dockerfile'
+    config_file_path = f'src/algorithms/{algorithm}/config.yaml'
 
-    print("Dockerfile Path: ", dockerfile_path)
-
-    if os.path.exists(dockerfile_path):
-        # If Dockerfile exists, build the image
-        session.run('docker', 'build', '-t', image_name, '-f', dockerfile_path, f'src/Algorithms/{algorithm}')
-    else:
-        # If Dockerfile doesn't exist, look into the config.yaml file
-        print(f'Dockerfile for {algorithm} not found at {dockerfile_path}')
+    # Start by checking the config file for DockerHub image details
+    if os.path.exists(config_file_path):
+        print(f'Checking config file at {config_file_path}')
+        with open(config_file_path, 'r') as file:
+            config = yaml.safe_load(file)
         
-        if os.path.exists(config_file_path):
-            print(f'Checking config file at {config_file_path}')
-            with open(config_file_path, 'r') as file:
-                config = yaml.safe_load(file)
-            
-            # Extract the Docker image name from the config
-            org = config.get('docker_image', {}).get('org')
-            name = config.get('docker_image', {}).get('name')
-            tag = config.get('docker_image', {}).get('tag')
-            docker_image_name = f'{org}/{name}:{tag}' if org and name and tag else None
-            algorithm_folder_name = config.get('algorithm_folder_name', None)
+        org = config.get('docker_image', {}).get('org')
+        name = config.get('docker_image', {}).get('name')
+        tag = config.get('docker_image', {}).get('tag')
+        docker_image_name = f'{org}/{name}:{tag}' if org and name and tag else None
+        algorithm_folder_name = config.get('algorithm_folder_name', None)
 
+        # Save the algorithm folder name in a file
+        with open('/tmp/algorithm_folder_name.txt', 'w') as file:
+            file.write(algorithm_folder_name)
+
+        # Attempt to pull the image from DockerHub
+        try:
+            print(f'Trying to pull the Docker image: {docker_image_name}')
+            session.run('docker', 'pull', docker_image_name)
+            print(f'Successfully pulled Docker image from DockerHub: {docker_image_name}')
             # Save the Docker image name in a file
             with open('/tmp/docker_image_name.txt', 'w') as file:
                 file.write(docker_image_name)
-
-            with open('/tmp/algorithm_folder_name.txt', 'w') as file:
-                file.write(algorithm_folder_name)
-                
-            if docker_image_name:
-                print(f'Found Docker image name in config: {docker_image_name}')
-                # Pull the Docker image from DockerHub
-                session.run('docker', 'pull', docker_image_name)
+        except Exception as e:
+            print(f'Failed to pull Docker image from DockerHub. Error: {e}')
+            # Proceed to build from Dockerfile if pull fails
+            if os.path.exists(dockerfile_path):
+                print("Pull failed; attempting to build locally from Dockerfile.")
+                session.run('docker', 'build', '-t', image_name, '-f', dockerfile_path, f'src/algorithms/{algorithm}')
+                # Save the locally built Docker image name in a file
+                with open('/tmp/docker_image_name.txt', 'w') as file:
+                    file.write(image_name)
             else:
-                session.error(f'Docker image name not found in {config_file_path}')
-        else:
-            session.error(f'Config file not found at {config_file_path}')
+                session.error(f'Neither Docker image on DockerHub nor Dockerfile found for {algorithm}')
+
+    else:
+        # If the config file does not exist, report an error
+        session.error(f'Config file not found at {config_file_path}')
 
 @nox.session
 def build_interface(session):
     """Build the Gradio docker Image"""
     if len(session.posargs) > 0:
-        interface = session.posargs[0] 
+        interface = session.posargs[0]
+        algorithm = session.posargs[1]
     else:
         interface = 'gradio'
     print("Building Interface Nox-File: ", interface)
 
-    image_name = f'{interface}-image'
+    image_name = f'{algorithm}_{interface}_image'
     print("Image Name: ", image_name)
 
-    dockerfile_path = f'src/build/Dockerfiles/{interface.capitalize()}.Dockerfile'
+    dockerfile_path = f'src/build/dockerfiles/{interface.capitalize()}.Dockerfile'
     print("Dockerfile Path: ", dockerfile_path)
 
     # Read the Docker image name from the file
@@ -94,6 +98,7 @@ def build_interface(session):
         
     if interface == 'gradio':
         session.run('docker', 'build', '-f', 'Gradio.Dockerfile', '--build-arg',  f'BASE_IMAGE={base_image}', '--build-arg',  f'FOLDER_NAME={algorithm_folder_name}', '-t', image_name, '-f', dockerfile_path, 'src/build')
+        session.run('docker', 'build', '-f', 'Gradio.Dockerfile', '--build-arg',  f'BASE_IMAGE={base_image}', '--build-arg',  f'FOLDER_NAME={algorithm_folder_name}', '-t', image_name, '-f', dockerfile_path, 'src/Build')
     elif interface == 'jupyter':
         session.run('docker', 'build', '-f', 'Jupyter.Dockerfile', '--build-arg',  f'BASE_IMAGE={base_image}', '--build-arg',  f'FOLDER_NAME={algorithm_folder_name}', '-t', image_name, '-f', dockerfile_path, 'src/build')
 

--- a/src/algorithms/cellpose_inference/config.yaml
+++ b/src/algorithms/cellpose_inference/config.yaml
@@ -377,6 +377,7 @@ results:
     label: "Download Outputs"
     description: "Directory containing the output files"
     cli_tag : "None"
+    file_count: multiple
     optional: True
     section_id: "output-section"
     mode: "beginner"

--- a/src/algorithms/threshold_inference/Dockerfile
+++ b/src/algorithms/threshold_inference/Dockerfile
@@ -1,8 +1,12 @@
 # Define an image to start from 
-FROM python:3.10.0-slim
+FROM python:3.9-slim
 
 # Set the working directory within the container
 WORKDIR /bilayers
 
+COPY threshold.py /bilayers
+
 # Install the dependencies for the specific algorithm
 RUN python -m pip install scipy==1.9.1 scikit-image==0.20.0
+
+CMD ["python"]

--- a/src/algorithms/threshold_inference/Dockerfile
+++ b/src/algorithms/threshold_inference/Dockerfile
@@ -9,4 +9,7 @@ COPY threshold.py /bilayers
 # Install the dependencies for the specific algorithm
 RUN python -m pip install scipy==1.9.1 scikit-image==0.20.0
 
+# Precompile Python module
+RUN python -m compileall /bilayers/threshold.py
+
 CMD ["python"]

--- a/src/algorithms/threshold_inference/config.yaml
+++ b/src/algorithms/threshold_inference/config.yaml
@@ -5,22 +5,22 @@ parameters:
     description: "Upload all images to be analyzed"
     file_count: multiple
     default: "directory"
-    cli_tag: ""
+    cli_tag: "--folder"
     optional: False
     section_id: "input-args"
-    folder_name: "input_images"
+    folder_name: "/bilayers/input_images"
     mode: "beginner"
   - name: threshold_method
     type: radio
     label: "Select a Threshold Method"
     description: "Select a threshold method to segment the image"
     options:
-      - label: "Otsu"
-        value: "Otsu"
-      - label: "Li"
-        value: "Li"
-    default: "Otsu"
-    cli_tag: ""
+      - label: "otsu"
+        value: "otsu"
+      - label: "li"
+        value: "li"
+    default: "otsu"
+    cli_tag: "--threshold_method"
     optional: False
     section_id: "input-args"
     mode: "beginner"
@@ -29,7 +29,7 @@ parameters:
     label: "Object Minimum Diameter Size"
     description: "Minimum diameter of objects in pixels"
     default: 5
-    cli_tag: ""
+    cli_tag: "--min_size"
     optional: False
     section_id: "input-args"
     mode: "beginner"
@@ -38,10 +38,20 @@ parameters:
     label: "Object Maximum Diameter Size"
     description: "Maximum diameter of objects in pixels"
     default: 20
-    cli_tag: ""
+    cli_tag: "--max_size"
     optional: False
     section_id: "input-args"
     mode: "beginner"
+  - name: save_dir
+    type: textbox
+    label: "Save Directory"
+    description: "directory to save output files"
+    output_dir_set: True
+    default: "/bilayers/input_images"
+    cli_tag: "--save_dir"
+    optional: True
+    section_id: "output-args"
+    mode: "advanced"
 
 display_only:
 

--- a/src/algorithms/threshold_inference/threshold.py
+++ b/src/algorithms/threshold_inference/threshold.py
@@ -108,11 +108,11 @@ def get_image_files_from_folder(folder_path):
     # List of supported image file extensions
     image_extensions = ['.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.tif']
 
-    # Get all files in the folder and filter by image extensions
+    # Get all files in the folder and filter by image extensions and also dont include the files with _output in the name
     image_files = [
         os.path.join(folder_path, file)
         for file in os.listdir(folder_path)
-        if os.path.splitext(file)[1].lower() in image_extensions
+        if os.path.splitext(file)[1].lower() in image_extensions and "_output" not in file
     ]
 
     return image_files

--- a/src/algorithms/threshold_inference/threshold.py
+++ b/src/algorithms/threshold_inference/threshold.py
@@ -1,28 +1,23 @@
+import argparse
+import os
 import scipy
 import skimage
-import os
 import numpy
 
-def example_function(image_list, threshold_method, min_size, max_size):
+
+def example_function(image_list, threshold_method, min_size, max_size, save_dir):
     """
     Example function that will threshold, label, and then filter objects
-    based on size.
-
-    This function also save the arrays and returns the file save paths. The file
-    save paths will be read by gr.File and allow the user to download the
-    analysed images.
+    based on size. This function also saves the arrays and returns the
+    file save paths, which can be downloaded by the user.
     """
     # Store output filenames to be returned
     output_filelist = list()
 
-    # Check: Type of image_list: To resolve 'list doesnt have attribute name'
-    print(f"image_list type: {type(image_list)}")
-
     for image_path in image_list:
         # Load the image
         print("My Input Image Path: ", image_path)
-        image = skimage.io.imread(image_path.name)
-        
+        image = skimage.io.imread(image_path)
 
         # Threshold the image
         if threshold_method.casefold() == "otsu":
@@ -31,7 +26,7 @@ def example_function(image_list, threshold_method, min_size, max_size):
             th_image = image > skimage.filters.threshold_li(image)
         else:
             raise NotImplementedError
-        
+
         # Label the image
         labeled_image = skimage.measure.label(th_image)
 
@@ -49,15 +44,104 @@ def example_function(image_list, threshold_method, min_size, max_size):
         labeled_image[area_image > max_allowed_area] = 0
 
         # Construct filename from input
-
         base_filename = os.path.basename(image_path).split(".")[0]
-        base_dir = os.path.dirname(image_path)
-        output_filename = os.path.join(base_dir, base_filename + "_output.tiff")
-        
+        output_filename = os.path.join(save_dir, base_filename + "_output.tiff")
+
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+
         # Save file
         skimage.io.imsave(output_filename, labeled_image)
+        print(f"Output saved to: {output_filename}")
 
+        # Append output filename to the list
         output_filelist.append(output_filename)
 
     # Return the list of file names
     return output_filelist
+
+def parse_arguments():
+    """
+    Parse the command-line arguments using argparse.
+    """
+    parser = argparse.ArgumentParser(
+        description="Threshold images and filter objects by size."
+    )
+
+    parser.add_argument(
+        "--folder",
+        required=True,
+        help="Path to the folder containing input images."
+    )
+    parser.add_argument(
+        "--threshold_method",
+        choices=["otsu", "li"],
+        required=True,
+        help="Thresholding method to use ('otsu' or 'li')."
+    )
+    parser.add_argument(
+        "--min_size",
+        type=float,
+        required=True,
+        help="Minimum size of objects to retain."
+    )
+    parser.add_argument(
+        "--max_size",
+        type=float,
+        required=True,
+        help="Maximum size of objects to retain."
+    )
+
+    parser.add_argument(
+        "--save_dir",
+        required=True,
+        help="Path to the folder to save output images."
+    )
+
+    return parser.parse_args()
+
+
+def get_image_files_from_folder(folder_path):
+    """
+    Get a list of image files from the specified folder.
+    """
+    # List of supported image file extensions
+    image_extensions = ['.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.tif']
+
+    # Get all files in the folder and filter by image extensions
+    image_files = [
+        os.path.join(folder_path, file)
+        for file in os.listdir(folder_path)
+        if os.path.splitext(file)[1].lower() in image_extensions
+    ]
+
+    return image_files
+
+
+def main():
+    # Parse the arguments
+    args = parse_arguments()
+
+    # Get list of image files from the folder
+    image_list = get_image_files_from_folder(args.folder)
+
+    if not image_list:
+        print("No images found in the specified folder.")
+        return
+
+    # Call the example function
+    output_filelist = example_function(
+        image_list=image_list,
+        threshold_method=args.threshold_method,
+        min_size=args.min_size,
+        max_size=args.max_size,
+        save_dir=args.save_dir
+    )
+
+    # Print the output file paths for the user to access
+    for file_path in output_filelist:
+        print(f"Output saved to: {file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/build/dockerfiles/Gradio.Dockerfile
+++ b/src/build/dockerfiles/Gradio.Dockerfile
@@ -10,7 +10,7 @@ ARG FOLDER_NAME
 WORKDIR /bilayers
 
 # Install the dependencies for the gradio app
-RUN python -m pip install pyyaml gradio==4.43.0 gradio_client==1.3.0 huggingface-hub==0.23.4 pydantic==2.7.4
+RUN python -m pip install pyyaml gradio==4.44.1 gradio_client==1.3.0 huggingface-hub==0.23.4 pydantic==2.7.4
 
 # Install numpy and opencv-python
 RUN python -m pip install numpy==1.23.0 opencv-python-headless==4.5.3.56 matplotlib==3.5.1

--- a/src/build/parse/gradio_template.py.j2
+++ b/src/build/parse/gradio_template.py.j2
@@ -112,7 +112,7 @@ def generate_cli_command(cli_tags, **kwargs):
                     if value == "None":
                         if optional is False:
                             error_message = f"{label} needs to have some value. It's Mandatory!"
-                            raise gr.Error(error_message)
+                            raise gr.Error(error_message, duration = None)
                         else:
                             continue
                 # If the parameter is a list (mainly for parameter files), convert it to a string
@@ -143,7 +143,7 @@ def generate_cli_command(cli_tags, **kwargs):
                     value = None
                     if optional is False:
                         error_message = f"{label} needs to have some value. It's Mandatory!"
-                        raise gr.Error(error_message)
+                        raise gr.Error(error_message, duration = None)
                 # If the cli_tag is None, don't include it in the command but if cli_tag is "" then just include the value
                 elif value is not None:
                     if cli_tag != "None":
@@ -302,7 +302,7 @@ def on_submit(
     except subprocess.CalledProcessError as e:
         error_message = "Please take a screenshot of this error and raise an issue at the Bilayers repository on GitHub."
         error_message += f"Command failed with error: {e.stderr.decode()}\n\n"
-        raise gr.Error(error_message)
+        raise gr.Error(error_message, duration = None)
         
 
 {% if parameters is not none -%}
@@ -325,7 +325,7 @@ def on_submit(
 {% elif param_conf.type == 'files' %}
 {{ param_conf.label | lower | replace(" ", "_") }}_description = gr.Markdown(value="{{ param_conf.description }}")
 {{ param_conf.label | lower | replace(" ", "_") }} = gr.Files(label="{{ param_conf.label }}", file_count="{{ param_conf.file_count }}")
-{%- endif %}
+{% endif %}
 
 
 {%- endfor %}  

--- a/src/build/parse/jupyter_shell_command_template.py.j2
+++ b/src/build/parse/jupyter_shell_command_template.py.j2
@@ -6,7 +6,7 @@ import traceback
 import urllib.parse
 
 try:
-    res = subprocess.run(cli_command.value, shell=True, check=True, stdout=None, stderr=subprocess.PIPE)
+    res = subprocess.run(cli_command.value, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     {% raw %}
     !{cli_command.value}
     {% endraw %}


### PR DESCRIPTION
**The current PR focuses on fixing/resolving -** 
1. Threshold should work seamlessly using cli_tag
    [details]: Previously, threshold algorithm was dependent on the function rather than cli_tag. Now, `threshold.py` is tweaked to have it's own `cli_tag`. 
2. `gradio` and `gradio-client` version updates - it's more advanced than one updated [here](https://github.com/bilayer-containers/bilayers/pull/54) 
4. At `build_docker.sh` file it provides both algorithm and interface names - [see here](https://github.com/bilayer-containers/bilayers/blob/threshold_fix/build_docker.sh#L7-L8)
5. noxsession - `build_algorithm` logic is updated in terms of it'll always look for docker-image on DockerHub if not available then build's image from local Dockerfile (In short logic is swapped - previously, it was prioritizing the build from local Dockerfile and now it's prioritizing pulling the available docker-image from dockerHub) - [here](https://github.com/bilayer-containers/bilayers/blob/threshold_fix/noxfile.py#L37-L74)
6.  noxsession - `build_interface` naming convention of each final docker-image holding `algorithm X interface` is updated [here](https://github.com/bilayer-containers/bilayers/blob/threshold_fix/noxfile.py#L86) - hence, naming conflicts can be avoided

**Still at Threshold algorithm problem persists -** 
1. `threshold_inference X jupyter` whilst the output_folder is same as the input_folder, it replicates the analysis on the generated_output. so, in a way it produces one extra output! (See here #58)