### PR TITLE
Open files with explicit utf-8 encoding; document Streamlit + CellProfiler plugin

### DIFF
--- a/docs/custom_algorithm/steps_to_create.md
+++ b/docs/custom_algorithm/steps_to_create.md
@@ -21,8 +21,8 @@ git remote add upstream https://github.com/bilayer-containers/bilayers.git
 
 ## 2. Add Your Algorithm Folder
 - Open the project in VS Code
-- Navigate to `src/bilayers/algorithms` and create a new folder for your algorithm
-- **Naming convention:** Use `algorithm_inference` or `algorithm_training` based on the task 
+- Navigate to `algorithms/` at the repo root and create a new folder for your algorithm
+- **Naming convention:** Use `algorithm_inference` or `algorithm_training` based on the task
 - Add a `__init__.py` file to your folder
 - Add a `config.yaml` file to your folder 
 

--- a/docs/custom_algorithm/supported_interfaces.md
+++ b/docs/custom_algorithm/supported_interfaces.md
@@ -6,10 +6,14 @@ authors:
       - Broad Institute of MIT and Harvard
 ---
 
-Bilayers supports two primary interface types for interacting with deep-learning models:
+Bilayers supports four interface types for interacting with image-analysis algorithms:
 
-1. **Gradio** – A no-code web-based UI  
+1. **Gradio** – A no-code web-based UI
 2. **Jupyter Notebook** – An interactive coding environment
+3. **Streamlit** – A scriptable web-based UI tuned for richer custom layouts
+4. **CellProfiler plugin** – A Python plugin runnable from within CellProfiler
+
+The first three produce a containerized web/notebook app on DockerHub. The CellProfiler plugin produces a `.py` file that drops directly into a CellProfiler installation — it intentionally does not produce its own container.
 
 ## Gradio : Instant Web-Based Interface
 
@@ -26,3 +30,21 @@ Gradio provides a quick and easy way to demo your machine learning model through
 Jupyter Notebooks offer a flexible, interactive environment where users can run and modify code. [Learn More](https://jupyter-notebook.readthedocs.io/en/latest/)
 
 ![JupyterNB](../images/custom_algorithm/JupyterNB.png)
+
+---
+
+## Streamlit
+
+**Best for:** Users who want a scriptable web UI with richer custom layouts than Gradio provides.
+
+Streamlit lets you compose data apps from ordinary Python, with native widgets for uploads, sliders, and result displays. Bilayers' Streamlit generator wires your algorithm's `cli_tag`s straight into the rendered widgets and emits a `streamlit_app.py` you can run with `streamlit run streamlit_app.py`. [Learn More](https://streamlit.io/)
+
+---
+
+## CellProfiler plugin
+
+**Best for:** Users who already run CellProfiler pipelines and want your algorithm to appear as a module they can drop into a pipeline.
+
+The CellProfiler-plugin generator picks a CellProfiler module category from your config's input/output types (e.g. `image → object` becomes "Image Segmentation", `image → measurement` becomes "Measurement") and emits a `run<YourAlgorithm>.py` file. Place that file in your CellProfiler plugins directory and the module shows up in the pipeline editor on the next restart. [Learn More about CellProfiler plugins](https://plugins.cellprofiler.org/).
+
+Note: unlike Gradio / Jupyter / Streamlit, this interface does not produce a Docker image of its own — it produces a Python plugin file that runs against an existing CellProfiler install.

--- a/interfaces/cellprofiler_plugin/generate.py
+++ b/interfaces/cellprofiler_plugin/generate.py
@@ -273,7 +273,7 @@ def generate(interface_input: InterfaceInput) -> None:
     # join folders and file name - file name MUST match plugin name (but in lowercase) to work
     cellprofiler_plugin_path = output_dir / f"{plugin_name.lower()}.py"
 
-    with open(cellprofiler_plugin_path, "w") as f:
+    with open(cellprofiler_plugin_path, "w", encoding="utf-8") as f:
         f.write(cellprofiler_plugin_code)
 
     print("CellProfiler plugin generated successfully!!")

--- a/interfaces/gradio/generate.py
+++ b/interfaces/gradio/generate.py
@@ -132,7 +132,7 @@ def generate(interface_input: InterfaceInput) -> None:
 
     gradio_app_path = output_dir / "app.py"
 
-    with open(gradio_app_path, "w") as f:
+    with open(gradio_app_path, "w", encoding="utf-8") as f:
         f.write(gradio_app_code)
 
     print("app.py generated successfully!!")

--- a/interfaces/jupyter/generate.py
+++ b/interfaces/jupyter/generate.py
@@ -141,7 +141,7 @@ def generate(interface_input: InterfaceInput) -> None:
 
     jupyter_notebook_path = output_dir / "generated_notebook.ipynb"
 
-    with open(jupyter_notebook_path, "w") as f:
+    with open(jupyter_notebook_path, "w", encoding="utf-8") as f:
         nbf.write(jupyter_app_code, f)
 
     print("Jupyter notebook saved as generated_notebook.ipynb")

--- a/interfaces/streamlit/generate.py
+++ b/interfaces/streamlit/generate.py
@@ -100,7 +100,7 @@ def generate(interface_input: InterfaceInput) -> None:
 
     streamlit_app_path = output_dir / "streamlit_app.py"
 
-    with open(streamlit_app_path, "w") as f:
+    with open(streamlit_app_path, "w", encoding="utf-8") as f:
         f.write(streamlit_app_code)
 
     print("streamlit_app.py generated successfully!!")

--- a/src/bilayers/parse.py
+++ b/src/bilayers/parse.py
@@ -12,7 +12,7 @@ def load_config(config_path: Union[str, Path]) -> dict[str, Any]:
     if not config_path.exists():
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
-    with open(config_path, "r") as file:
+    with open(config_path, "r", encoding="utf-8") as file:
         config = yaml.safe_load(file)
 
     return config

--- a/src/bilayers/schema.py
+++ b/src/bilayers/schema.py
@@ -3,7 +3,7 @@ from pprint import pprint
 
 from ._blpath import package_path
 
-with (package_path() / "schema.yaml").open("r") as f:
+with (package_path() / "schema.yaml").open("r", encoding="utf-8") as f:
     schema = yaml.safe_load(f)
 
 

--- a/tests/regression/test_generate_regression.py
+++ b/tests/regression/test_generate_regression.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def normalize_notebook(path: Path):
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         nb = json.load(f)
 
     for cell in nb.get("cells", []):
@@ -55,4 +55,4 @@ def test_generate_regression():
             else:
                 golden_file = golden_base_dir / "runclassicalsegmentation.py"
 
-            assert golden_file.read_text() == generated_file.read_text()
+            assert golden_file.read_text(encoding="utf-8") == generated_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Pass `encoding="utf-8"` everywhere the codebase reads or writes a generated artifact, config YAML, or golden file. Fixes a reproducible Windows-only `UnicodeEncodeError` / `UnicodeDecodeError` in `bilayers_cli generate` (Jupyter interface) and in `tests/regression/test_generate_regression.py`. Latent on Gradio / Streamlit / CellProfiler-plugin writes too — those happen to produce ASCII-only output today.
- Add Streamlit and CellProfiler-plugin sections to `docs/custom_algorithm/supported_interfaces.md` (previously only Gradio + Jupyter were listed), and fix a stale `src/bilayers/algorithms` path in `steps_to_create.md` (algorithms live at the repo root). Closes #117 in spirit — its body just says "update this in new PR".

## Why the encoding fix

Running `bilayers_cli generate tests/fixtures/classical_segmentation/config.yaml` on Windows dies at the Jupyter step:

```
Running generate for jupyter...
Error occurred while generating for jupyter: 'charmap' codec can't encode characters in position 23795-23796: character maps to <undefined>
```

`pytest tests/regression/test_generate_regression.py` then fails mirror-imaged with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 23800` reading the golden notebook.

Root cause: every `open(...)` site involved — the four interface generators under `interfaces/*/generate.py`, `src/bilayers/parse.py::load_config`, `src/bilayers/schema.py` loading the LinkML YAML at import time, and `tests/regression/test_generate_regression.py`'s `normalize_notebook` / golden-file comparison — uses Python's locale-dependent default encoding. On Linux/macOS that's UTF-8; on Windows that's cp1252. The bug is silent on Linux and fails closed on Windows.

Fix is mechanical: pass `encoding="utf-8"` at every read/write of a file that is canonically UTF-8 (`.py`, `.ipynb`, `.yaml`). After the patch, all four interfaces generate cleanly on Windows; behaviour on Linux/macOS is unchanged (the default already was UTF-8 there).

## Why the docs fix

`pyproject.toml` registers `[project.entry-points."bilayers.interfaces"]` for all four interfaces (gradio, jupyter, streamlit, cellprofiler_plugin), and `tests/regression/test_generate_regression.py` exercises all four against golden files. But `docs/custom_algorithm/supported_interfaces.md` only documented Gradio and Jupyter — a reader of the docs had no way to learn that the other two exist.

The CellProfiler-plugin section also calls out that, unlike the other three, it does not produce a Docker image of its own (matching the `scripts/build_docker.sh` and `.github/workflows/docker-build.yml` behavior, and aligned with the intent in #146).

While in those docs, I noticed `steps_to_create.md` told contributors to put their algorithm under `src/bilayers/algorithms` — that directory has never existed; algorithm fixtures live in `algorithms/` at the repo root. One-line fix.

## Test plan

- [x] `pytest tests/` on Windows (Python 3.14, venv): **17 / 17 pass**. Previously the regression test failed on this platform with `UnicodeDecodeError` reading the golden notebook.
- [x] `bilayers_cli generate tests/fixtures/classical_segmentation/config.yaml` on Windows: all four interfaces (gradio, jupyter, streamlit, cellprofiler_plugin) generate cleanly. Previously the Jupyter step printed `Error occurred while generating for jupyter: 'charmap' codec ...` and produced an unreadable notebook.
- [x] `bilayers_cli generate --cli ...` emits `python -m classical_segmentation --folder /bilayers/input_images --threshold_method otsu --min_size 5 --max_size 20 --save_dir /bilayers/output_images`.
- [x] `ruff check src tests noxfile.py` → `All checks passed!`.
- [x] CI replay on my fork (this same `test.yml` workflow, `ubuntu-latest`, Python 3.9): **green** — https://github.com/xX-its-amit-Xx/bilayers/actions/runs/26635076654. Confirms no regression on the Linux + Python 3.9 path the upstream CI uses.

The docs changes are MyST markdown; I did not run `myst build --html` locally (MyST is a JS toolchain that wasn't part of the dev install). Eyeball-reviewed against the existing pages' tone and structure.

## Open questions for maintainers

1. `noxfile.py` reads / writes a handful of `tmp_path("…").txt` files without `encoding=`. They currently only hold ASCII (platform tags, docker image names, algorithm folder names), so the same Windows bug doesn't bite there. Worth normalizing in this PR for consistency, or leaving for a separate noxfile cleanup?
2. Issue #117's body just says "update this in new PR" — happy to expand further (screenshots of the Streamlit and CellProfiler interfaces, or pages dedicated to each rather than two more sections on the existing one) if you have a preferred direction.
3. There are two more spots in the docs with the same "Gradio and Jupyter only" claim that I deliberately scoped *out* of this PR: [`docs/standard/WhatIsBilayers.md:11`](docs/standard/WhatIsBilayers.md#L11) and [`docs/custom_algorithm/understanding_config.md:10`](docs/custom_algorithm/understanding_config.md#L10) (the latter also has the same stale `src/bilayers/algorithms` path I fixed in `steps_to_create.md`). Happy to extend the PR if you'd prefer one larger docs sweep.
