### PR TITLE
fix: open generated/config files with explicit utf-8 encoding

### DIFF
--- a/interfaces/cellprofiler_plugin/generate.py
+++ b/interfaces/cellprofiler_plugin/generate.py
@@ -273,7 +273,7 @@ def generate(interface_input: InterfaceInput) -> None:
     # join folders and file name - file name MUST match plugin name (but in lowercase) to work
     cellprofiler_plugin_path = output_dir / f"{plugin_name.lower()}.py"
 
-    with open(cellprofiler_plugin_path, "w") as f:
+    with open(cellprofiler_plugin_path, "w", encoding="utf-8") as f:
         f.write(cellprofiler_plugin_code)
 
     print("CellProfiler plugin generated successfully!!")

--- a/interfaces/gradio/generate.py
+++ b/interfaces/gradio/generate.py
@@ -132,7 +132,7 @@ def generate(interface_input: InterfaceInput) -> None:
 
     gradio_app_path = output_dir / "app.py"
 
-    with open(gradio_app_path, "w") as f:
+    with open(gradio_app_path, "w", encoding="utf-8") as f:
         f.write(gradio_app_code)
 
     print("app.py generated successfully!!")

--- a/interfaces/jupyter/generate.py
+++ b/interfaces/jupyter/generate.py
@@ -141,7 +141,7 @@ def generate(interface_input: InterfaceInput) -> None:
 
     jupyter_notebook_path = output_dir / "generated_notebook.ipynb"
 
-    with open(jupyter_notebook_path, "w") as f:
+    with open(jupyter_notebook_path, "w", encoding="utf-8") as f:
         nbf.write(jupyter_app_code, f)
 
     print("Jupyter notebook saved as generated_notebook.ipynb")

--- a/interfaces/streamlit/generate.py
+++ b/interfaces/streamlit/generate.py
@@ -100,7 +100,7 @@ def generate(interface_input: InterfaceInput) -> None:
 
     streamlit_app_path = output_dir / "streamlit_app.py"
 
-    with open(streamlit_app_path, "w") as f:
+    with open(streamlit_app_path, "w", encoding="utf-8") as f:
         f.write(streamlit_app_code)
 
     print("streamlit_app.py generated successfully!!")

--- a/src/bilayers/parse.py
+++ b/src/bilayers/parse.py
@@ -12,7 +12,7 @@ def load_config(config_path: Union[str, Path]) -> dict[str, Any]:
     if not config_path.exists():
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
-    with open(config_path, "r") as file:
+    with open(config_path, "r", encoding="utf-8") as file:
         config = yaml.safe_load(file)
 
     return config

--- a/src/bilayers/schema.py
+++ b/src/bilayers/schema.py
@@ -3,7 +3,7 @@ from pprint import pprint
 
 from ._blpath import package_path
 
-with (package_path() / "schema.yaml").open("r") as f:
+with (package_path() / "schema.yaml").open("r", encoding="utf-8") as f:
     schema = yaml.safe_load(f)
 
 

--- a/tests/regression/test_generate_regression.py
+++ b/tests/regression/test_generate_regression.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def normalize_notebook(path: Path):
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         nb = json.load(f)
 
     for cell in nb.get("cells", []):
@@ -55,4 +55,4 @@ def test_generate_regression():
             else:
                 golden_file = golden_base_dir / "runclassicalsegmentation.py"
 
-            assert golden_file.read_text() == generated_file.read_text()
+            assert golden_file.read_text(encoding="utf-8") == generated_file.read_text(encoding="utf-8")


### PR DESCRIPTION
> 🤖 **AI disclosure:** This PR body and the code changes were drafted by Claude (Anthropic's AI), then reviewed, manually tested on Windows, and validated against a cross-platform CI replay by me before submission. Commits carry a `Co-Authored-By: Claude` trailer. Splitting this out from #178 per @gnodar01's review.

## Summary

Pass `encoding="utf-8"` everywhere the codebase reads or writes a generated artifact, config YAML, or LinkML schema. Fixes a reproducible Windows-only `UnicodeEncodeError` / `UnicodeDecodeError` in `bilayers_cli generate` (Jupyter interface) and in `tests/regression/test_generate_regression.py`. Latent on Gradio / Streamlit / CellProfiler-plugin writes too — they happen to produce ASCII-only output today.

## Repro

On Windows (Python 3.14, fresh venv with `pip install -e ".[test,interfaces,plugins,linkml]"`):

```
$ bilayers_cli generate tests/fixtures/classical_segmentation/config.yaml
Parsing config...
Running generate for cellprofiler_plugin...
CellProfiler plugin generated successfully!!
Running generate for gradio...
app.py generated successfully!!
Running generate for jupyter...
Error occurred while generating for jupyter: 'charmap' codec can't encode characters in position 23795-23796: character maps to <undefined>
Running generate for streamlit...
streamlit_app.py generated successfully!!
Finished generating all interfaces
```

`pytest tests/regression/test_generate_regression.py` then fails mirror-imaged with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 23800` reading the golden notebook.

## Root cause

Every `open(...)` site involved uses Python's locale-dependent default encoding:

- `interfaces/{gradio,jupyter,streamlit,cellprofiler_plugin}/generate.py` — generator writes
- `src/bilayers/parse.py::load_config` — config YAML read
- `src/bilayers/schema.py` — LinkML schema YAML load at import time
- `tests/regression/test_generate_regression.py` — `normalize_notebook` JSON read and `read_text()` golden comparison

On Linux/macOS the locale default is UTF-8; on Windows it's cp1252. nbformat emits non-cp1252 bytes (e.g. `0x8f`) in some notebook fields, which breaks the round-trip on Windows. The bug is silent on Linux and fails closed on Windows.

## Fix

Pass `encoding="utf-8"` at every read/write of a file that is canonically UTF-8 (`.py`, `.ipynb`, `.yaml`). Eight sites; the change is mechanical.

## Test plan

- [x] `pytest tests/` on Windows (Python 3.14, venv): **17 / 17 pass**. Previously the regression test failed on this platform.
- [x] `bilayers_cli generate tests/fixtures/classical_segmentation/config.yaml` on Windows: all four interfaces generate cleanly. Previously Jupyter failed.
- [x] `bilayers_cli generate --cli ...` emits `python -m classical_segmentation --folder /bilayers/input_images --threshold_method otsu --min_size 5 --max_size 20 --save_dir /bilayers/output_images`.
- [x] `ruff check src tests noxfile.py` → `All checks passed!`.
- [x] CI replay on my fork (this same `test.yml` workflow on `ubuntu-latest` + Python 3.9): **green** — https://github.com/xX-its-amit-Xx/bilayers/actions/runs/26635076654. The Linux side is unchanged by this patch (default encoding was already UTF-8 there), which is the intended outcome.

## Open question for maintainers

`noxfile.py` reads / writes a handful of `tmp_path("…").txt` files without `encoding=`. They currently only hold ASCII (platform tags, docker image names, algorithm folder names) so the same bug doesn't bite there. Happy to normalize them here for consistency or leave for a separate noxfile cleanup — your call.
