### PR TITLE
docs: list Streamlit and CellProfiler-plugin interfaces; fix algorithms path

### DIFF
--- a/docs/custom_algorithm/steps_to_create.md
+++ b/docs/custom_algorithm/steps_to_create.md
@@ -21,8 +21,8 @@ git remote add upstream https://github.com/bilayer-containers/bilayers.git
 
 ## 2. Add Your Algorithm Folder
 - Open the project in VS Code
-- Navigate to `src/bilayers/algorithms` and create a new folder for your algorithm
-- **Naming convention:** Use `algorithm_inference` or `algorithm_training` based on the task 
+- Navigate to `algorithms/` at the repo root and create a new folder for your algorithm
+- **Naming convention:** Use `algorithm_inference` or `algorithm_training` based on the task
 - Add a `__init__.py` file to your folder
 - Add a `config.yaml` file to your folder 
 

--- a/docs/custom_algorithm/supported_interfaces.md
+++ b/docs/custom_algorithm/supported_interfaces.md
@@ -6,10 +6,14 @@ authors:
       - Broad Institute of MIT and Harvard
 ---
 
-Bilayers supports two primary interface types for interacting with deep-learning models:
+Bilayers supports four interface types for interacting with image-analysis algorithms:
 
-1. **Gradio** – A no-code web-based UI  
+1. **Gradio** – A no-code web-based UI
 2. **Jupyter Notebook** – An interactive coding environment
+3. **Streamlit** – A scriptable web-based UI tuned for richer custom layouts
+4. **CellProfiler plugin** – A Python plugin runnable from within CellProfiler
+
+The first three produce a containerized web/notebook app on DockerHub. The CellProfiler plugin produces a `.py` file that drops directly into a CellProfiler installation — it intentionally does not produce its own container.
 
 ## Gradio : Instant Web-Based Interface
 
@@ -26,3 +30,21 @@ Gradio provides a quick and easy way to demo your machine learning model through
 Jupyter Notebooks offer a flexible, interactive environment where users can run and modify code. [Learn More](https://jupyter-notebook.readthedocs.io/en/latest/)
 
 ![JupyterNB](../images/custom_algorithm/JupyterNB.png)
+
+---
+
+## Streamlit
+
+**Best for:** Users who want a scriptable web UI with richer custom layouts than Gradio provides.
+
+Streamlit lets you compose data apps from ordinary Python, with native widgets for uploads, sliders, and result displays. Bilayers' Streamlit generator wires your algorithm's `cli_tag`s straight into the rendered widgets and emits a `streamlit_app.py` you can run with `streamlit run streamlit_app.py`. [Learn More](https://streamlit.io/)
+
+---
+
+## CellProfiler plugin
+
+**Best for:** Users who already run CellProfiler pipelines and want your algorithm to appear as a module they can drop into a pipeline.
+
+The CellProfiler-plugin generator picks a CellProfiler module category from your config's input/output types (e.g. `image → object` becomes "Image Segmentation", `image → measurement` becomes "Measurement") and emits a `run<YourAlgorithm>.py` file. Place that file in your CellProfiler plugins directory and the module shows up in the pipeline editor on the next restart. [Learn More about CellProfiler plugins](https://plugins.cellprofiler.org/).
+
+Note: unlike Gradio / Jupyter / Streamlit, this interface does not produce a Docker image of its own — it produces a Python plugin file that runs against an existing CellProfiler install.


### PR DESCRIPTION
> 🤖 **AI disclosure:** This PR body and the code changes were drafted by Claude (Anthropic's AI), then reviewed and approved by me before submission. Commits carry a `Co-Authored-By: Claude` trailer. Splitting this out from #178 per @gnodar01's review.

Closes #117 in spirit (the issue body just says "update this in new PR").

## Summary

- Add **Streamlit** and **CellProfiler-plugin** sections to `docs/custom_algorithm/supported_interfaces.md` (it previously only documented Gradio and Jupyter).
- Fix a stale `src/bilayers/algorithms` path in `docs/custom_algorithm/steps_to_create.md` — algorithm fixtures live in `algorithms/` at the repo root.

## Why

`pyproject.toml` registers `[project.entry-points."bilayers.interfaces"]` for all four interfaces (gradio, jupyter, streamlit, cellprofiler_plugin), and `tests/regression/test_generate_regression.py` exercises all four against checked-in golden files. But the published "Supported Interfaces" doc only mentioned Gradio and Jupyter — a reader had no way to learn that the other two are first-class.

The CellProfiler-plugin section calls out that, unlike the other three, it does not produce a Docker image of its own (matching the `scripts/build_docker.sh` and `.github/workflows/docker-build.yml` behavior, and aligned with the intent in #146). I tried to be neutral on whether that's permanent or transitional — let me know if you want different framing.

The `steps_to_create.md` change is a one-line path fix: `src/bilayers/algorithms` → `algorithms/`. That directory has never existed under `src/`.

## What this PR does *not* do

There are two more spots in the docs with the same stale claims that I deliberately scoped out so this PR stays focused on the issue. Happy to extend if you'd prefer one larger sweep, or open a follow-up if you'd rather keep PRs small:

- [`docs/standard/WhatIsBilayers.md:11`](docs/standard/WhatIsBilayers.md#L11) — same "currently supports Gradio and Jupyter Notebook" claim.
- [`docs/custom_algorithm/understanding_config.md:10`](docs/custom_algorithm/understanding_config.md#L10) — same stale `bilayers/src/bilayers/algorithms/algorithm_name/config.yaml` path.

## Test plan

- [x] Markdown lint via eyeball against existing pages' tone and structure.
- [x] No code paths affected; existing tests (17/17 on Windows + green on fork CI from the encoding-fix PR) are unchanged.
- [ ] Did not run `myst build --html` locally — MyST is a JS toolchain that wasn't in my dev install. If you can point me at a render preview link I'll check screenshots-vs-rendered there.

## Open question

Issue #117's body just says "update this in new PR" — happy to expand further (e.g. screenshots of the Streamlit / CellProfiler interfaces, or dedicated pages for each instead of two more sections on the existing one) if you have a preferred direction.
