### PR TITLE
Keep secret parameters out of the CLI sequence

### DIFF
--- a/src/bilayers/parse.py
+++ b/src/bilayers/parse.py
@@ -74,8 +74,10 @@ def build_cli_sequence(parsed_config: Config) -> dict[str, dict[str, Any]]:
         item["source"] = "input"
         all_items.append(item)
 
-    # Add parameters
+    # Add parameters, except secrets which are passed as environment variables, never on the CLI
     for name, config in parameters.items():
+        if config.get("type") == "secret":
+            continue
         item = dict(config)
         item["name"] = name
         item["source"] = "parameter"


### PR DESCRIPTION
`build_cli_sequence()` skips any param `type: secret`.

This goes here rather than in each template because it's the one function every interface takes its argument order from. This means its invariant to any secret `cli_tag` and no future template can resurface it by iterating the sequence naively.


### For later
This test could be added to assert a secret carrying a `cli_tag` won't get into the CLI (should yield `["run_algorithm", "--threshold 5"]`):

```
def test_secret_not_in_cli():
    """Secrets are passed as environment variables, so they must not reach the CLI even with a cli_tag."""
    config = Config(
        {
            "citations": {},
            "algorithm_folder_name": "",
            "inputs": {},
            "outputs": {},
            "display_only": None,
            "exec_function": {"name": "", "script": "", "module": "", "hidden_args": None, "cli_command": "run_algorithm"},
            "parameters": {
                "threshold": {"name": "threshold", "type": "integer", "cli_tag": "--threshold", "cli_order": 1, "default": 5},
                "hf_token": {"name": "hf_token", "type": "secret", "cli_tag": "--token", "cli_order": 2, "default": "hunter2"},
            },
        }
    )
    cli_command = generate_cli_command(config)
    assert cli_command == ["run_algorithm", "--threshold 5"]
```

Depends on[ bilayers-schema#10](https://github.com/bilayer-containers/bilayers-schema/pull/10). Works together with [bilayers-targets#14](https://github.com/bilayer-containers/bilayers-targets/pull/14). 