### PR TITLE
Add schema_version to test configs

### DIFF
--- a/tests/fixtures/classical_segmentation/config.yaml
+++ b/tests/fixtures/classical_segmentation/config.yaml
@@ -1,3 +1,5 @@
+schema_version: "bilayers-0.1.0"
+
 citations:
   - name: "Classical Segmentation"
     doi: doi_number

--- a/tests/fixtures/instanseg_inference/config.yaml
+++ b/tests/fixtures/instanseg_inference/config.yaml
@@ -1,3 +1,5 @@
+schema_version: "bilayers-0.1.0"
+
 citations:
   - name: "InstanSeg in Brightfield Images"
     doi: 10.48550/arXiv.2408.15954

--- a/tests/test_algorithm/correct_validation_config.yaml
+++ b/tests/test_algorithm/correct_validation_config.yaml
@@ -1,3 +1,5 @@
+schema_version: "bilayers-0.1.0"
+
 citations:
   - name: "Testing"
     doi: xyz


### PR DESCRIPTION
Follow-up to https://github.com/bilayer-containers/bilayers-schema/pull/11, which adds schema_version as a required top-level key to the schema (read G from issue https://github.com/bilayer-containers/bilayers-schema/issues/8.


### Changes in: 

- `correct_validation_config.yaml` needs it, the test asserts "No issues found".
- The two configs under `tests/fixtures/` get it for consistency. `generate` does not validate and no template reads the key, so the golden files are unchanged.

<br>

## Important note - why CI fails here
bilayers repo installs **bilayers-schema** and **bilayers-algorithms** from the tip of their main branches (not any pinned release), so CI here _breaks_ the moment the schema PR merges and stays broken until the algorithms PR merges. 
SO &rarr; Merge the **algorithms** PR right after **schema's**. The red gap is just the minutes between the two merges.

**Merge order:** bilayers-schema → bilayers-algorithms → bilayers.